### PR TITLE
feat: set ble defaults to match ios connection parameters

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -47,7 +47,7 @@ static uint8_t input_report_button_byte_0{
 static uint8_t input_report_button_byte_1{
     1}; // 1 for pro controller, 5 for ps5, unneeded for most controllers
 static uint8_t ble_min_interval_units{12}; // 15ms
-static uint8_t ble_max_interval_units{24}; // 30ms
+static uint8_t ble_max_interval_units{12}; // 15ms
 static uint8_t bt_qos_units{0};            // disabled by default
 
 // runtime state for HID mode
@@ -397,8 +397,8 @@ void hidh_callback(void *handler_args, esp_event_base_t base, int32_t id, void *
             .bda = {0},
             .min_int = ble_min_interval_units, // * 1.25ms
             .max_int = ble_max_interval_units, // * 1.25ms
-            .latency = 0,
-            .timeout = 400,
+            .latency = 4,                      // 4 packets allowed to be skipped
+            .timeout = 100,                    // 1000ms timeout
         };
         memcpy(conn_params.bda, bda, ESP_BD_ADDR_LEN);
         fmt::print("Setting BLE connection parameters\n");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update to match default iOS connection parameters for HID gamepads which seem to be:
  * `connection interval = 15ms`
  * `connection latency = 4` (max of 4 skipped packets)
  * `connection timeout = 1000ms`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More representative of the latency / connection state that iOS uses right now.
![CleanShot 2024-06-06 at 11 28 36](https://github.com/finger563/esp-latency-test/assets/213467/91ba76c5-2577-4da2-988d-040bbb15f600)
