### PR TITLE
Feature/nvs adc thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ sdkconfig
 sdkconfig.old
 .DS_Store
 env
+__pycache__/

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -44,20 +44,6 @@ menu "Latency Test Configuration"
             The maximum delay / shift in milliseconds between when the button is
             released and when the next button press is triggered.
 
-    config UPPER_THRESHOLD
-        int "Threshold value (mV) for registering a screen on event"
-        default 80
-        help
-            The threshold value for registering a screen on event. The value is
-            in units of millivolts.
-
-    config LOWER_THRESHOLD
-        int "Threshold value (mV) for registering a screen off event"
-        default 30
-        help
-            The threshold value for registering a screen off event. The value is
-            in units of millivolts.
-
     config BUTTON_PRESS_LEVEL
         int "Level which indicates a button press"
         default 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove upper/lower thresholds from kconfig
* Update main so that upper/lower thresholds are loaded from NVS and can be manipulated via CLI

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since the thresholds are test-setup dependent (and phone dependent), being able to configure them at runtime as you modify your test setup makes more sense than having to recompile code.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running main on a QtPy ESP32 Pico.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-06-25 at 15 47 47](https://github.com/finger563/esp-latency-test/assets/213467/4e846995-7516-4672-a32b-efeb741a4c9f)
![CleanShot 2024-06-25 at 15 48 09](https://github.com/finger563/esp-latency-test/assets/213467/f37cff03-66fd-4562-b981-bfc6386f796d)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.